### PR TITLE
Убрано кодирование контента виджета

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     ],
     "require": {
         "ext-dom": "*",
-        "ext-mbstring": "*",
         "yiisoft/yii2": "~2.0.52",
         "symfony/css-selector": "7.2.0",
         "symfony/dom-crawler": "7.2.4"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "evgenidev/yii2-dynamicform",
+    "name": "frogbarbarian/yii2-dynamicform",
     "description": "It is widget to yii2 framework to clone form elements in a nested manner, maintaining accessibility.",
     "keywords": [
         "wbraganca",
@@ -25,6 +25,7 @@
         }
     ],
     "require": {
+        "ext-mbstring": "*",
         "ext-dom": "*",
         "yiisoft/yii2": "~2.0.52",
         "symfony/css-selector": "7.2.0",

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,10 @@
         }
     ],
     "require": {
-        "yiisoft/yii2": "~2.0.5",
-        "symfony/css-selector": "~2.8|~3.0",
-        "symfony/dom-crawler": "~2.8|~3.0"
+        "ext-dom": "*",
+        "yiisoft/yii2": "~2.0.52",
+        "symfony/css-selector": "7.2.0",
+        "symfony/dom-crawler": "7.2.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "frogbarbarian/yii2-dynamicform",
+    "name": "evgenidev/yii2-dynamicform",
     "description": "It is widget to yii2 framework to clone form elements in a nested manner, maintaining accessibility.",
     "keywords": [
         "wbraganca",

--- a/src/DynamicFormWidget.php
+++ b/src/DynamicFormWidget.php
@@ -230,7 +230,7 @@ class DynamicFormWidget extends \yii\base\Widget
     {
         $content = ob_get_clean();
         $crawler = new Crawler();
-        $crawler->addHTMLContent(htmlspecialchars($content,  HTML_ENTITIES, 'UTF-8'), \Yii::$app->charset);
+        $crawler->addHTMLContent($content, \Yii::$app->charset);
         $results = $crawler->filter($this->widgetItem);
         $document = new \DOMDocument('1.0', \Yii::$app->charset);
         $document->appendChild($document->importNode($results->first()->getNode(0), true));

--- a/src/DynamicFormWidget.php
+++ b/src/DynamicFormWidget.php
@@ -230,7 +230,7 @@ class DynamicFormWidget extends \yii\base\Widget
     {
         $content = ob_get_clean();
         $crawler = new Crawler();
-        $crawler->addHTMLContent(mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8'), \Yii::$app->charset);
+        $crawler->addHTMLContent(htmlspecialchars($content,  HTML_ENTITIES, 'UTF-8'), \Yii::$app->charset);
         $results = $crawler->filter($this->widgetItem);
         $document = new \DOMDocument('1.0', \Yii::$app->charset);
         $document->appendChild($document->importNode($results->first()->getNode(0), true));


### PR DESCRIPTION
Убрано кодирование контента в виду того, что используемая функция устарела в применяемом виде, а Crawler сам прекрасно все делает